### PR TITLE
Mods updates system

### DIFF
--- a/PulsarModLoader/CustomGUI/GUIMain.cs
+++ b/PulsarModLoader/CustomGUI/GUIMain.cs
@@ -4,6 +4,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using HarmonyLib;
+using PulsarModLoader.Utilities;
+using Steamworks;
 using UnityEngine;
 using static UnityEngine.GUILayout;
 
@@ -95,8 +97,14 @@ namespace PulsarModLoader.CustomGUI
                         ModListScroll = BeginScrollView(ModListScroll);
                         {
                             for (ushort p = 0; p < mods.Count; p++)
-                                if (Button(mods[p].Name))
-                                    selectedMod = p;
+                            {
+                                var mod = mods[p];
+                                var name = mods[p].Name;
+                                if (ModManager.Instance.UpdatesAviable.Any(m => m.Mod == mod))
+                                    name = "(!) " + name;
+								if (Button(name))
+									selectedMod = p;
+							}
                         }
                         EndScrollView();
                     }
@@ -122,6 +130,15 @@ namespace PulsarModLoader.CustomGUI
                                 if (mod.LongDescription != string.Empty)
                                     Label($"Long Description: {mod.LongDescription}");
                                 Label($"MPRequirement: {((MPModChecks.MPRequirement)mod.MPRequirements).ToString()}");
+                                Space(1f);
+                                var result = ModManager.Instance.UpdatesAviable.FirstOrDefault(av => av.Mod == mod);
+								if (result != null)
+                                {
+                                    if (result.IsUpdated)
+                                        Label("Restart the game to apply the changes!");
+									else if(Button($"Update this mod to version {result.Data.Version}?"))
+                                            ModUpdateCheck.UpdateMod(result);
+								}
                             }
                             EndScrollView();
                         }

--- a/PulsarModLoader/MPModChecks/MPModCheckManager.cs
+++ b/PulsarModLoader/MPModChecks/MPModCheckManager.cs
@@ -184,7 +184,7 @@ namespace PulsarModLoader.MPModChecks
                     {
                         MyStream.Position = 0;
                         byte[] Hash = MyHasher.ComputeHash(MyStream);
-                        ProcessedMods[i] = new MPModDataBlock(currentMod.HarmonyIdentifier(), currentMod.Name, currentMod.Version, (MPRequirement)currentMod.MPRequirements, currentMod.ModID, Hash);
+                        ProcessedMods[i] = new MPModDataBlock(currentMod.HarmonyIdentifier(), currentMod.Name, currentMod.Version, (MPRequirement)currentMod.MPRequirements, currentMod.VersionLink, Hash);
                     }
                 }
             }

--- a/PulsarModLoader/PMLConfig.cs
+++ b/PulsarModLoader/PMLConfig.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace PulsarModLoader
 {
@@ -9,7 +10,9 @@ namespace PulsarModLoader
 
         public static SaveValue<bool> DebugMode = new SaveValue<bool>("DebugMode", false);
 
-        public static void SetDefault()
+        public static SaveValue<DateTime> LastPMLUpdateCheck = new SaveValue<DateTime>("LastPMLUpdateCheck", DateTime.Today.AddDays(-2));
+
+		public static void SetDefault()
         {
 	        ModInfoTextAnchor.Value = TextAnchor.UpperLeft;
         }

--- a/PulsarModLoader/PulsarMod.cs
+++ b/PulsarModLoader/PulsarMod.cs
@@ -11,7 +11,7 @@ namespace PulsarModLoader
     /// </summary>
     public abstract class PulsarMod
     {
-        private FileVersionInfo VersionInfo;
+        internal FileVersionInfo VersionInfo;
 
         /// <summary>
         /// 
@@ -31,7 +31,6 @@ namespace PulsarModLoader
             // Can't use Assembly.GetExecutingAssembly() or it grabs this assembly instead of the mod's!
             // Executing assembly is technically PML's during base class methods.
             Assembly asm = GetType().Assembly;
-            VersionInfo = FileVersionInfo.GetVersionInfo(asm.Location);
 
             harmony = new Harmony(HarmonyIdentifier());
             harmony.PatchAll(asm);
@@ -176,10 +175,10 @@ namespace PulsarModLoader
             enabled = true;
         }
 
-        /// <summary>
-        /// Mod ID for future feature involving download IDs for a public webserver
-        /// </summary>
-        public virtual string ModID
+		/// <summary>
+		/// A link to the version file containing information about the latest version of the mod. Null if there is no link for this mod.
+		/// </summary>
+		public virtual string VersionLink
         {
             get
             {

--- a/PulsarModLoader/PulsarModLoader.csproj
+++ b/PulsarModLoader/PulsarModLoader.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Utilities\ExceptionWarningPatch.cs" />
     <Compile Include="Utilities\Logger.cs" />
     <Compile Include="Utilities\Messaging.cs" />
+    <Compile Include="Utilities\ModUpdateCheck.cs" />
     <Compile Include="Utilities\Uploaders\IUploader.cs" />
     <Compile Include="Utilities\Uploaders\TransferShUploader.cs" />
   </ItemGroup>

--- a/PulsarModLoader/Utilities/ModUpdateCheck.cs
+++ b/PulsarModLoader/Utilities/ModUpdateCheck.cs
@@ -1,0 +1,87 @@
+﻿using PulsarModLoader.Chat.Commands;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Valve.Newtonsoft.Json;
+
+namespace PulsarModLoader.Utilities
+{
+	internal static class ModUpdateCheck
+	{
+		internal static bool IsUpdateAviable(PulsarMod mod)
+		{
+#if DEBUG
+			return false; // disabled for debug builds
+#endif
+			if (PMLConfig.DebugMode.Value) // disabled for debug mode
+				return false;
+
+			if (string.IsNullOrEmpty(mod.VersionLink)) // disabled for mods without link
+				return false;
+
+			using (var web = new System.Net.WebClient())
+			{
+				web.Headers.Add("user-agent", "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.71 Safari/537.36");
+				var file = JsonConvert.DeserializeObject<VersionFile>(web.DownloadString(mod.VersionLink));
+				var result = CompareVersions(mod.Version, file.Version);
+
+				if (result)
+					ModManager.Instance.UpdatesAviable.Add(new UpdateModInfo() { Mod = mod, Data = file });
+
+				return result;
+			}
+		}
+
+		private static bool CompareVersions(string current, string fromServer)
+		{
+			var currentParsed = current.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).ToArray();
+			var fromServerParsed = fromServer.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries).Select(int.Parse).ToArray();
+
+			for(int i = 0; i < currentParsed.Length; i++)
+			{
+				if (currentParsed[i] > fromServerParsed[i]) // return false if "1.4" vs "1.3"
+					return false;
+
+				if (currentParsed[i] < fromServerParsed[i]) // return true if "1.4" vs "1.5"
+					return true;
+			}
+
+			if (fromServerParsed.Length > currentParsed.Length) // return true if CompareVersions("1.4", "1.4.1")
+				return true;
+
+			return false; // if "1.4" vs "1.4"
+		}
+
+		internal static void UpdateMod(UpdateModInfo info)
+		{
+			//info.Mod.Unload();
+			var path = info.Mod.VersionInfo.FileName;
+			using (var web = new System.Net.WebClient())
+			{
+				web.Headers.Add("user-agent", "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.71 Safari/537.36");
+				var dll = web.DownloadData(info.Data.DownloadLink);
+				File.WriteAllBytes(path, dll);
+				//ModManager.Instance.LoadMod(path);
+			}
+			info.IsUpdated = true;
+		}
+
+		internal struct VersionFile
+		{
+			public string Version;
+			public string DownloadLink;
+		}
+
+		internal class UpdateModInfo
+		{
+			public PulsarMod Mod;
+			public VersionFile Data;
+			public bool IsUpdated = false;
+		}
+	}
+}


### PR DESCRIPTION
During the loading of mods checks for updates for the mod, if the developer has provided a link to a special link.
Also allows you to update the mod with the click of a button. Unfortunately, the changes will only apply after restarting the game.

Special file: https://github.com/BadRyuner/PulsarBotIntegration/blob/master/Version.json
How to provide: https://github.com/BadRyuner/PulsarBotIntegration/blob/master/Mod.cs#L27

How it looks in the game:
![image](https://github.com/PULSAR-Modders/pulsar-mod-loader/assets/54708336/4e23c154-5136-4560-84f9-024f9ae7f2fb)
(!) - means this mod is outdated.

To indicate a new version, the modder only needs to update his Version.json on the master branch of the mod by changing Version and DownloadLink.