### PR TITLE
Add string for License in mod loader

### DIFF
--- a/PulsarModLoader/ModManager.cs
+++ b/PulsarModLoader/ModManager.cs
@@ -288,7 +288,7 @@ namespace PulsarModLoader
 					activeMods.Add(mod.Name, mod);
                     OnModSuccessfullyLoaded?.Invoke(mod.Name, mod);
 
-                    Logger.Info($"Loaded mod: {mod.Name} Version {mod.Version} Author: {mod.Author}");
+                    Logger.Info($"Loaded Mod: {mod.Name}, Version: {mod.Version}, Author: {mod.Author}, License: {mod.License}");
 
                     if (ModUpdateCheck.IsUpdateAviable(mod))
                         Logger.Info($"↑ ↑ ↑ !This mod is outdated! ↑ ↑ ↑");

--- a/PulsarModLoader/PulsarMod.cs
+++ b/PulsarModLoader/PulsarMod.cs
@@ -48,6 +48,17 @@ namespace PulsarModLoader
         /// <returns></returns>
         public abstract string HarmonyIdentifier();
 
+        /// <License>
+        /// License of the mod.
+        /// </License>
+        public virtual string License
+        {
+            get
+            {
+                return String.Empty;
+            }
+        }
+
         /// <summary>
         /// Version of mod.  Displayed in mod list.
         /// </summary>


### PR DESCRIPTION
Addded
 - Notification of License in log
 - String for License (mod.License)

Fixed
 - Incistencys in mod loading log lines

Example log
18:13:41 [PML] Loaded Mod: ReactorTempDisplay, Version: 1.15, Author: FloppyDisk, License: GNU GPL-3.0