### PR TITLE
Changes made to allow BepInEx to work inplace of the Injector

### DIFF
--- a/PulsarModLoader/BepInPlugin.cs
+++ b/PulsarModLoader/BepInPlugin.cs
@@ -1,0 +1,45 @@
+﻿using BepInEx;
+using BepInEx.Logging;
+using HarmonyLib;
+using PulsarModLoader.Patches;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PulsarModLoader
+{
+    [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.USERS_PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
+    [BepInProcess("PULSAR_LostColony.exe")]
+    public class BepinPlugin : BaseUnityPlugin
+    {
+        internal static BepinPlugin instance;
+        internal static readonly Harmony Harmony = new Harmony(MyPluginInfo.PLUGIN_GUID);
+        internal static ManualLogSource Log;
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "N/A")]
+        private void Awake()
+        {
+            instance = this;
+            Log = Logger;
+
+            try
+            {
+                //File.WriteAllText("doorstop_hello.log", "Hello from Unity!");
+                PMLInject();
+                Log.LogInfo($"{MyPluginInfo.PLUGIN_GUID} Initialized.");
+            }
+            catch (Exception e)
+            {
+                Log.LogInfo($"{MyPluginInfo.PLUGIN_GUID} Init Exception\n{e}");
+            }
+
+        }
+
+        private static void PMLInject()
+        {
+            //Get PLGlobal::Start Patched
+            Harmony.Patch(AccessTools.Method(typeof(PLGlobal), "Start"), new HarmonyMethod(typeof(PLGlobalStart), "Prefix"));
+        }
+    }
+}

--- a/PulsarModLoader/CustomGUI/GUIMain.cs
+++ b/PulsarModLoader/CustomGUI/GUIMain.cs
@@ -300,6 +300,7 @@ namespace PulsarModLoader.CustomGUI
                                 GUI.skin.label.alignment = TextAnchor.MiddleCenter;
                                 Label($"PulsarModLoader - Unofficial mod loader for PULSAR: Lost Colony.");
                                 Label($"Version: {ModManager.Instance.PMLVersionInfo.FileVersion}");
+                                Label("<color=yellow><b>BepInEx Varient</b></color>");
                                 Label($"\n\nDeveloped by Tom Richter, Dragon, 18107, BadRyuner");
                                 BeginHorizontal();
                                 FlexibleSpace();

--- a/PulsarModLoader/ModManager.cs
+++ b/PulsarModLoader/ModManager.cs
@@ -383,7 +383,7 @@ namespace PulsarModLoader
         internal void UnloadMod(PulsarMod mod, ref Harmony harmony)
         {
             activeMods.Remove(mod.Name); // Removes selected mod from activeMods
-            harmony.UnpatchAll(mod.HarmonyIdentifier()); // Removes all patches from selected mod
+            //harmony.UnpatchAll(mod.HarmonyIdentifier()); // Removes all patches from selected mod
             OnModUnloaded?.Invoke(mod);
             Logger.Info($"Unloaded mod: {mod.Name} Version {mod.Version} Author: {mod.Author}");
             GC.Collect();

--- a/PulsarModLoader/MyPluginInfo.cs
+++ b/PulsarModLoader/MyPluginInfo.cs
@@ -1,0 +1,17 @@
+﻿#pragma warning disable CS1591
+namespace PulsarModLoader
+{
+    //Auto-Generated File. Created by PreBuild.ps1
+    public class MyPluginInfo
+    {
+        public const string PLUGIN_GUID = "PulsarModdingTeam.PulsarModLoader";
+        public const string PLUGIN_NAME = "PulsarModLoader";
+        public const string USERS_PLUGIN_NAME = "Pulsar Mod Loader";
+        public const string PLUGIN_VERSION = "0.0.0";
+        public const string PLUGIN_DESCRIPTION = "Pulsar Mod Loader";
+        public const string PLUGIN_ORIGINAL_AUTHOR = "PulsarModdingTeam";
+        public const string PLUGIN_AUTHORS = "PulsarModdingTeam";
+        public const string PLUGIN_THUNDERSTORE_ID = "";
+    }
+}
+#pragma warning restore CS1591

--- a/PulsarModLoader/Patches/PLGlobalStart.cs
+++ b/PulsarModLoader/Patches/PLGlobalStart.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using System.IO;
+using System.Reflection;
 using UnityEngine;
 
 namespace PulsarModLoader.Patches
@@ -13,6 +14,10 @@ namespace PulsarModLoader.Patches
         {
             if (!modsLoaded)
             {
+
+                var harmony = new Harmony("wiki.pulsar.pml");
+                harmony.PatchAll(Assembly.GetExecutingAssembly());
+
                 //Events Init
                 new PulsarModLoader.Events();
 

--- a/PulsarModLoader/Patches/PLGlobalStart.cs
+++ b/PulsarModLoader/Patches/PLGlobalStart.cs
@@ -14,13 +14,16 @@ namespace PulsarModLoader.Patches
         {
             if (!modsLoaded)
             {
-                //Logging adjustments
-                Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
-                Application.SetStackTraceLogType(LogType.Warning, StackTraceLogType.None);
+                if (BepinPlugin.instance != null)
+                {
+                    //Logging adjustments
+                    Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
+                    Application.SetStackTraceLogType(LogType.Warning, StackTraceLogType.None);
 
-                //Patch Everything
-                var harmony = new Harmony("wiki.pulsar.pml");
-                harmony.PatchAll(Assembly.GetExecutingAssembly());
+                    //Patch Everything
+                    var harmony = new Harmony("wiki.pulsar.pml");
+                    harmony.PatchAll(Assembly.GetExecutingAssembly());
+                }
 
                 //Events Init
                 new PulsarModLoader.Events();

--- a/PulsarModLoader/Patches/PLGlobalStart.cs
+++ b/PulsarModLoader/Patches/PLGlobalStart.cs
@@ -14,7 +14,11 @@ namespace PulsarModLoader.Patches
         {
             if (!modsLoaded)
             {
+                //Logging adjustments
+                Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
+                Application.SetStackTraceLogType(LogType.Warning, StackTraceLogType.None);
 
+                //Patch Everything
                 var harmony = new Harmony("wiki.pulsar.pml");
                 harmony.PatchAll(Assembly.GetExecutingAssembly());
 

--- a/PulsarModLoader/PulsarModLoader.csproj
+++ b/PulsarModLoader/PulsarModLoader.csproj
@@ -38,8 +38,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.2.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.2.2\lib\net472\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Talespire.BepInEx.5.4.22\lib\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="ACTk.Runtime, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -55,9 +55,36 @@
       <HintPath>..\lib\Assembly-CSharp-firstpass.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="BepInEx, Version=5.4.19.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Talespire.BepInEx.5.4.22\lib\BepInEx.dll</HintPath>
+    </Reference>
+    <Reference Include="BepInEx.Harmony, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Talespire.BepInEx.5.4.22\lib\BepInEx.Harmony.dll</HintPath>
+    </Reference>
+    <Reference Include="BepInEx.Preloader, Version=5.4.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Talespire.BepInEx.5.4.22\lib\BepInEx.Preloader.dll</HintPath>
+    </Reference>
     <Reference Include="com.rlabrecque.steamworks.net">
       <HintPath>..\lib\com.rlabrecque.steamworks.net.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="HarmonyXInterop, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Talespire.BepInEx.5.4.22\lib\HarmonyXInterop.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Talespire.BepInEx.5.4.22\lib\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Talespire.BepInEx.5.4.22\lib\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Talespire.BepInEx.5.4.22\lib\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="MonoMod.RuntimeDetour, Version=22.1.29.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Talespire.BepInEx.5.4.22\lib\MonoMod.RuntimeDetour.dll</HintPath>
+    </Reference>
+    <Reference Include="MonoMod.Utils, Version=22.1.29.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Talespire.BepInEx.5.4.22\lib\MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="Pathfinding.Ionic.Zip.Reduced">
       <HintPath>..\lib\Pathfinding.Ionic.Zip.Reduced.dll</HintPath>
@@ -165,6 +192,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BepInPlugin.cs" />
     <Compile Include="Chat\Commands\ClearCommand.cs" />
     <Compile Include="Chat\Commands\CommandRouter\ChatCommandRouter.cs" />
     <Compile Include="Chat\Commands\CommandRouter\ChatInputPatch.cs" />
@@ -236,6 +264,7 @@
     <Compile Include="Keybinds\KeybindManager.cs" />
     <Compile Include="Keybinds\LoadFromXmlPatch.cs" />
     <Compile Include="Keybinds\PMLKeybind.cs" />
+    <Compile Include="MyPluginInfo.cs" />
     <Compile Include="Patches\AllowPMLRPCPatch.cs" />
     <Compile Include="ModMessage\ModMessage.cs" />
     <Compile Include="ModMessage\ModMessageHelper.cs" />
@@ -280,6 +309,10 @@
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Connected Services\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\RoR2.BepInEx.Analyzers.1.0.8\analyzers\dotnet\cs\BepInEx.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\RoR2.BepInEx.Analyzers.1.0.8\analyzers\dotnet\cs\BepInEx.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="CopyMarkdownFiles" AfterTargets="AfterBuild">

--- a/PulsarModLoader/packages.config
+++ b/PulsarModLoader/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Lib.Harmony" version="2.2.2" targetFramework="net472" />
+  <package id="RoR2.BepInEx.Analyzers" version="1.0.8" targetFramework="net472" developmentDependency="true" />
   <package id="System.IO" version="4.3.0" targetFramework="net472" />
   <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net472" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net472" />
@@ -9,4 +10,5 @@
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.X509Certificates" version="4.3.2" targetFramework="net472" />
+  <package id="Talespire.BepInEx" version="5.4.22" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
- PulsarModLoader can be injected using BepInEx and run mods like normal.
- PulsarModLoader untested with the normal Injector.
- Changes added for harmonyX (Short OpCodes get normalized)
![image](https://github.com/user-attachments/assets/a9832669-add6-4abf-826f-4fa43ea4d730)

https://github.com/BepInEx/HarmonyX/issues/69
